### PR TITLE
feat: Alias plugin edit endpoint opens in sideframe (#137)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* feat: Edit alias plugin opens in side-frame
 
 1.8.0 (2022-07-18)
 ==================

--- a/djangocms_alias/cms_plugins.py
+++ b/djangocms_alias/cms_plugins.py
@@ -51,7 +51,7 @@ class Alias(CMSPluginBase):
                 PluginMenuItem(
                     _('Edit Alias'),
                     edit_endpoint,
-                    action='',
+                    action='sideframe',
                     attributes={'icon': 'alias'},
                 ),
             ]

--- a/test_settings.py
+++ b/test_settings.py
@@ -105,6 +105,8 @@ HELPER_SETTINGS = {
         ('custom_alias_template', 'Custom Template Name'),
     ],
     "DEFAULT_AUTO_FIELD": "django.db.models.AutoField",
+    # Due to a recent temporary change in develop-4, we now need to confirm that we intend to use v4
+    "CMS_CONFIRM_VERSION4": True,
 }
 
 

--- a/tests/test_cms_plugins.py
+++ b/tests/test_cms_plugins.py
@@ -52,6 +52,7 @@ class AliasPluginTestCase(BaseAliasPluginTestCase):
         first, second = extra_items
         self.assertEqual(first.name, 'Edit Alias')
         self.assertEqual(first.url, alias.get_absolute_url())
+        self.assertEqual(first.action, 'sideframe')
 
         self.assertEqual(second.name, 'Detach Alias')
         self.assertEqual(second.action, 'modal')


### PR DESCRIPTION
* Edit alias plugin opens in side-frame

* Added cms4 confirmation