### PR TITLE
feat: Hiding aliases from admin index menu (#145)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 Unreleased
 ==========
-
+* feat: Hiding Aliases entry from admin index menu as aliases are managed through Alias Content
 * fix: Removed refs to missing static files (#143)
 
 1.10.0 (2022-09-21)

--- a/djangocms_alias/admin.py
+++ b/djangocms_alias/admin.py
@@ -102,6 +102,9 @@ class AliasAdmin(admin.ModelAdmin):
             sender=self.model,
         )
 
+    def has_module_permission(self, request):
+        return False
+
 
 @admin.register(AliasContent)
 class AliasContentAdmin(*alias_content_admin_classes):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,6 +1,7 @@
 from unittest import skipUnless
 
 from django.contrib.auth.models import Permission
+from django.urls import reverse
 from django.utils.formats import localize
 from django.utils.timezone import localtime
 
@@ -576,3 +577,37 @@ class CategoryAdminViewsTestCase(BaseAliasPluginTestCase):
         self.assertEqual(self.category.name, 'test category')
         self.category.set_current_language('de')
         self.assertEqual(self.category.name, 'Alias Kategorie')
+
+
+class AliasesManagerTestCase(BaseAliasPluginTestCase):
+
+    def test_aliases_admin_entry_is_hidden(self):
+        """
+        Aliases admin entry should not be available via the admin menu
+        """
+        index_url = reverse('admin:index')
+
+        self.client.force_login(self.superuser)
+
+        response = self.client.get(index_url)
+
+        unexpected_content = '<th scope="row"><a href="/en/admin/djangocms_alias/alias/">Aliases</a></th>'
+        expected_content = '<th scope="row"><a href="/en/admin/djangocms_alias/aliascontent/">Alias contents</a></th>'
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, expected_content)
+        self.assertNotContains(response, unexpected_content)
+
+    def test_aliases_endpoint_accessible_via_url(self):
+        """
+        Aliases admin endpoint should still be accessible via the endpoint
+        """
+        base_url = self.get_admin_url(AliasModel, "changelist")
+
+        with self.login_user_context(self.superuser):
+            response = self.client.get(base_url)
+
+        module_name = response.context_data['module_name']
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(module_name, 'aliases')


### PR DESCRIPTION
* Hiding Aliases from admin menu

* Updated test name

* Added test to ensure aliases is still accessible via url

* Update CHANGELOG.rst